### PR TITLE
Fix song stops playing after joining another voice channel

### DIFF
--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -480,7 +480,20 @@ class MusicCog(commands.Cog):
 
         destination = channel or ctx.author.voice.channel
         if ctx.voice_state.voice:
+            # Pause music before joining another channel (otherwise the song freezes)
+            was_playing = False
+            if ctx.voice_state.is_playing and ctx.voice_state.voice.is_playing():
+                ctx.voice_state.voice.pause()
+                was_playing = True
+
+            await asyncio.sleep(0.5)
             await ctx.voice_state.voice.move_to(destination)
+            await asyncio.sleep(0.5)
+
+            # Resume playing the music after joining if it was playing when the command was called.
+            # If paused while it was called, stay paused.
+            if was_playing and ctx.voice_state.voice.is_paused():
+                ctx.voice_state.voice.resume()
             return
 
         ctx.voice_state.voice = await destination.connect()


### PR DESCRIPTION
<!--
Hey! Thanks for creating a PR.
Please fill out the template below to make our review easier.
-->

## Description

When a bot is playing music and is sent to another voice channel via the join command, the music will freeze instead of continuing in the new voice channel. Modified the join command to prevent this from happening.


## Type of change

- [X] Bug or typo fix 
- [ ] New feature

## Checklist:

- [X] Code conforms to convention guidelines
- [X] Tested changes in a dev environment
- [ ] Updated documentation (if necessary)
