### PR TITLE
Temporarily disable file_cog

### DIFF
--- a/cogs/file_cog.py
+++ b/cogs/file_cog.py
@@ -147,5 +147,6 @@ class FileCog(commands.Cog):
 def setup(bot):
     # Adds cog to bot from main.py
     if config.STAGE != "dev":
-        # dont add this cog if we are in dev to avoid duplication, remove for testing
-        bot.add_cog(FileCog(bot))
+        # don't add this cog if we are in dev to avoid duplication, remove for testing
+        # bot.add_cog(FileCog(bot))
+        pass


### PR DESCRIPTION

<!--
Hey! Thanks for creating a PR.
Please fill out the template below to make our review easier.
-->

## Description

The PDF print functionality currently has no page limit or any limits on how many times a single PDF can be printed, so it can be easily abused. This functionality should only be added back once limitations are implemented.

## Type of change

- [X] Bug or typo fix 
- [ ] New feature

## Checklist:

- [X] Code conforms to convention guidelines
- [ ] Tested changes in a dev environment
- [ ] Updated documentation (if necessary)
