### PR TITLE
Update typo on cooldown to be one day

### DIFF
--- a/cogs/file_cog.py
+++ b/cogs/file_cog.py
@@ -154,7 +154,7 @@ class FileCog(commands.Cog):
                 logging.debug(f"Converting {attachment.filename} to images...")
 
                 # setting the preview activeness to expire a day from when it was used
-                expiration_date = int(time.time()) + 60
+                expiration_date = int(time.time()) + 60 * 60 * 24
                 logging.debug(
                     "This pdf can be previewed again at: " + str(expiration_date)
                 )


### PR DESCRIPTION
## Description
Fixed typo setting cooldown to 1 minute instead of 1 day
...

Fixes # (issue)

## Type of change

- [x] Bug or typo fix 
- [ ] New feature

## Checklist:

- [x] Code conforms to convention guidelines
- [x] Tested changes in a dev environment
- [x] Updated documentation (if necessary)
