### PR TITLE
[WIP] Update github action workflow to reflect new cloud storage

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,14 +37,14 @@ jobs:
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication
       - run: |-
-          gcloud --quiet auth configure-docker
+          gcloud --quiet auth configure-docker us-central1-docker.pkg.dev
 
       # Build the Docker image
       - name: Build
         run: |-
           docker build \
             -f build/Dockerfile.bot \
-            --tag "gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA" \
+            --tag "us-central1-docker.pkg.dev/$PROJECT_ID/REPOSITORY_NAME/$IMAGE:$GITHUB_SHA" \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF" \
             .


### PR DESCRIPTION

## Description
Container registry is to be deprecated, as such this will fix our build path to reflect the move to artifact-registry instead as per
https://cloud.google.com/artifact-registry/docs/transition/auto-migrate-gcr-ar
...

Fixes # (issue)

## Type of change

- [X] Bug or typo fix 
- [ ] New feature

## Checklist:

- [X] Code conforms to convention guidelines
- [X] Tested changes in a dev environment
